### PR TITLE
proxy: Make sure to use proxy when no_proxy var is undefined

### DIFF
--- a/lib/github-application.js
+++ b/lib/github-application.js
@@ -225,6 +225,9 @@ function getProxyAgent(proxy, baseUrl) {
           core.info(`using proxy '${envProxy}' for GitHub API calls`)
           return new HttpsProxyAgent(envProxy);
         }
+      } else {
+        core.info(`using proxy '${envProxy}' for GitHub API calls`)
+        return new HttpsProxyAgent(envProxy);
       }
     }
   }


### PR DESCRIPTION
no_proxy env var is used to avoid proxy for a list of urls, however the proxy must be used if the var is not defined.